### PR TITLE
Fix parent avatar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+
+- Fix: Show Parent even if we fallback for the main avatar
+
 ### [1.0.0+4]
 
 - bump package dependencies.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -210,7 +210,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 height: 20,
               ),
               Text(
-                'Rectangular Acter Avatars ',
+                'Space Acter Avatars ',
                 style: TextStyle(fontSize: 18, fontWeight: FontWeight.w500),
               ),
               Padding(
@@ -308,7 +308,7 @@ class _MyHomePageState extends State<MyHomePage> {
               ),
               const SizedBox(height: 20),
               Text(
-                'Rectangular Acter Avatars With Parent Badge',
+                'Space Acter Avatars With Parent Badge',
                 style: TextStyle(fontSize: 18, fontWeight: FontWeight.w500),
               ),
               Padding(
@@ -356,7 +356,10 @@ class _MyHomePageState extends State<MyHomePage> {
                           ),
                           avatarsInfo: [
                             AvatarInfo(
-                                uniqueId: uuid.v4(), displayName: 'Lorem Ipsum')
+                              displayName: "C-Space",
+                              uniqueId: uuid.v4(),
+                              avatar: AssetImage('assets/images/space-3.jpg'),
+                            ),
                           ],
                         ),
                         SizedBox(
@@ -409,6 +412,13 @@ class _MyHomePageState extends State<MyHomePage> {
                             uniqueId: uuid.v4(),
                             avatar: AssetImage('assets/images/space-3.jpg'),
                           ),
+                          avatarsInfo: [
+                            AvatarInfo(
+                              displayName: "C-Space",
+                              uniqueId: uuid.v4(),
+                              avatar: AssetImage('assets/images/space-3.jpg'),
+                            ),
+                          ],
                         ),
                       ],
                     ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0+3"
+    version: "1.0.0+4"
   args:
     dependency: transitive
     description:

--- a/lib/src/acter_avatar.dart
+++ b/lib/src/acter_avatar.dart
@@ -66,8 +66,25 @@ class _ActerAvatar extends State<ActerAvatar> {
   @override
   void initState() {
     super.initState();
+    _refreshAvatar();
+  }
+
+  @override
+  void didUpdateWidget(ActerAvatar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.avatarInfo.avatar != oldWidget.avatarInfo.avatar ||
+        widget.avatarInfo.avatarFuture != oldWidget.avatarInfo.avatarFuture) {
+      _refreshAvatar();
+    }
+  }
+
+  void _refreshAvatar() {
     ImageStreamListener listener =
         ImageStreamListener(setImage, onError: setImageError);
+
+    // reset
+    avatar = null;
+    imgSuccess = false;
 
     if (widget.avatarInfo.avatar != null) {
       widget.avatarInfo.avatar!

--- a/lib/src/acter_avatar.dart
+++ b/lib/src/acter_avatar.dart
@@ -42,18 +42,18 @@ class ActerAvatar extends StatefulWidget {
   /// Avatar gesture tap for parent badge of `DisplayMode.Space`.
   final void Function()? onParentBadgeTap;
 
-  ActerAvatar(
-      {Key? key,
-      required this.avatarInfo,
-      required this.mode,
-      this.onAvatarTap,
-      this.onParentBadgeTap,
-      this.avatarsInfo,
-      this.tooltip = TooltipStyle.Combined,
-      this.secondaryToolTip = TooltipStyle.Combined,
-      this.size,
-      this.badgeSize})
-      : super(key: key ?? Key('avatar-${avatarInfo.uniqueId}-$size'));
+  ActerAvatar({
+    Key? key,
+    required this.avatarInfo,
+    required this.mode,
+    this.onAvatarTap,
+    this.onParentBadgeTap,
+    this.avatarsInfo,
+    this.tooltip = TooltipStyle.Combined,
+    this.secondaryToolTip = TooltipStyle.Combined,
+    this.size,
+    this.badgeSize = 20,
+  }) : super(key: key ?? Key('avatar-${avatarInfo.uniqueId}-$size'));
 
   @override
   _ActerAvatar createState() => _ActerAvatar();
@@ -268,12 +268,20 @@ class _ActerAvatar extends State<ActerAvatar> {
   }
 
   Widget renderSpaceParent(BuildContext context) {
-    double badgeOverflow = badgeSize / 5;
+    if (widget.badgeSize == null) {
+      // nothing. ignore
+      return SizedBox.shrink();
+    }
+    final badgeSize = widget.badgeSize ?? 20;
     if (widget.avatarsInfo == null || widget.avatarsInfo!.isEmpty) {
-      return SizedBox(height: badgeSize + badgeOverflow);
+      return SizedBox(
+        height: badgeSize,
+        width: badgeSize,
+      );
     }
 
     final parentInfo = widget.avatarsInfo![0];
+    double badgeOverflow = badgeSize / 5;
 
     return Positioned(
       bottom: -badgeOverflow,
@@ -284,13 +292,14 @@ class _ActerAvatar extends State<ActerAvatar> {
           avatarInfo: parentInfo,
           mode: DisplayMode.Space,
           size: badgeSize,
+          badgeSize: null,
         ),
       ),
     );
   }
 
   Widget renderFallback(BuildContext context) {
-    double textFallbackSize = widget.size == null ? 48 : widget.size!;
+    double textFallbackSize = widget.size ?? 48;
     double multiFallbackSize = widget.size == null ? 48 : widget.size! * 2.0;
 
     /// Fallback

--- a/lib/src/constants/keys.dart
+++ b/lib/src/constants/keys.dart
@@ -6,6 +6,6 @@ class TestKeys {
   static const multiAvatarKey = Key('Multi-avatar');
   static const textAvatarKey = Key('Text-Avatar');
   static const circleAvatarKey = Key('Circle-Avatar');
-  static const rectangleAvatarKey = Key('Rectangle-Avatar');
+  static const spaceAvatarKey = Key('Space-Avatar');
   static const stackedAvatarKey = Key('Stacked-Avatar');
 }

--- a/test/acter_avatar_test.dart
+++ b/test/acter_avatar_test.dart
@@ -76,13 +76,13 @@ void main() {
     });
   });
 
-  group('Rectangular Avatar tests', () {
-    testWidgets('Rectangular Avatar with specified size',
+  group('Space Avatar tests', () {
+    testWidgets('Space Avatar with specified size',
         (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(
           body: ActerAvatar(
-            key: TestKeys.rectangleAvatarKey,
+            key: TestKeys.spaceAvatarKey,
             avatarInfo: AvatarInfo(uniqueId: 'test:acter.org'),
             mode: DisplayMode.Space,
             size: 36,
@@ -91,18 +91,17 @@ void main() {
       ));
       await tester.pumpAndSettle();
       final Size avatarSize =
-          tester.getSize(find.byKey(TestKeys.rectangleAvatarKey));
+          tester.getSize(find.byKey(TestKeys.spaceAvatarKey));
 
       // should expect specified fallback size
       expect(avatarSize.height, equals(36));
       expect(avatarSize.width, equals(36));
     });
-    testWidgets('Rectangular Avatar with fallback size',
-        (WidgetTester tester) async {
+    testWidgets('Space Avatar with fallback size', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(
           body: ActerAvatar(
-            key: TestKeys.rectangleAvatarKey,
+            key: TestKeys.spaceAvatarKey,
             avatarInfo: AvatarInfo(uniqueId: 'test:acter.org'),
             mode: DisplayMode.Space,
           ),
@@ -110,13 +109,13 @@ void main() {
       ));
       await tester.pumpAndSettle();
       final Size avatarSize =
-          tester.getSize(find.byKey(TestKeys.rectangleAvatarKey));
+          tester.getSize(find.byKey(TestKeys.spaceAvatarKey));
       // should expect default fallback avatar size
       expect(avatarSize.height, equals(48));
       expect(avatarSize.width, equals(48));
     });
 
-    testWidgets('Rectangular Avatar with NetworkImage render',
+    testWidgets('Space Avatar with NetworkImage render',
         (WidgetTester tester) async {
       final String imagePath =
           'https://st5.depositphotos.com/38460822/63964/i/600/depositphotos_639649504-stock-photo-mail-sign-sign-alphabet-made.jpg';
@@ -124,14 +123,14 @@ void main() {
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(
           body: ActerAvatar(
-            key: TestKeys.rectangleAvatarKey,
+            key: TestKeys.spaceAvatarKey,
             avatarInfo: AvatarInfo(uniqueId: '@test:acter.org', avatar: image),
             mode: DisplayMode.Space,
           ),
         ),
       ));
       await tester.pumpAndSettle();
-      final avatarFinder = find.byKey(TestKeys.rectangleAvatarKey);
+      final avatarFinder = find.byKey(TestKeys.spaceAvatarKey);
       // should expect `ActerAvatar` is present
       expect(avatarFinder, findsOneWidget);
       final avatar = avatarFinder.evaluate().first.widget as ActerAvatar;
@@ -139,12 +138,12 @@ void main() {
       expect(avatar.avatarInfo.avatar, NetworkImage(imagePath));
     });
 
-    testWidgets('Rectangular Avatar Parent Badge specified size',
+    testWidgets('Space Avatar Parent Badge specified size',
         (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(
           body: ActerAvatar(
-            key: TestKeys.rectangleAvatarKey,
+            key: TestKeys.spaceAvatarKey,
             avatarInfo: AvatarInfo(uniqueId: '@test:acter.org'),
             avatarsInfo: [AvatarInfo(uniqueId: 'Acter-Global')],
             mode: DisplayMode.Space,
@@ -153,20 +152,21 @@ void main() {
         ),
       ));
       await tester.pumpAndSettle();
-      final avatarFinder = find.byKey(TestKeys.rectangleAvatarKey);
+      final avatarFinder = find.byKey(TestKeys.spaceAvatarKey);
       // should expect `ActerAvatar` is present
       expect(avatarFinder, findsOneWidget);
-      final sizedBoxSize = tester.getSize(find.byType(SizedBox));
+      final innerAvatar = tester.getSize(find.descendant(
+          of: avatarFinder, matching: find.byType(ActerAvatar)));
       // expect parent badge specified size.
-      expect(sizedBoxSize.height, equals(35));
-      expect(sizedBoxSize.width, equals(35));
+      expect(innerAvatar.height, equals(35));
+      expect(innerAvatar.width, equals(35));
     });
-    testWidgets('Rectangular Avatar Parent Badge fallback size',
+    testWidgets('Space Avatar Parent Badge fallback size',
         (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(
           body: ActerAvatar(
-            key: TestKeys.rectangleAvatarKey,
+            key: TestKeys.spaceAvatarKey,
             avatarInfo: AvatarInfo(uniqueId: '@test:acter.org'),
             avatarsInfo: [AvatarInfo(uniqueId: 'Acter-Global')],
             mode: DisplayMode.Space,
@@ -174,15 +174,16 @@ void main() {
         ),
       ));
       await tester.pumpAndSettle();
-      final avatarFinder = find.byKey(TestKeys.rectangleAvatarKey);
+      final avatarFinder = find.byKey(TestKeys.spaceAvatarKey);
       // should expect `ActerAvatar` is present
       expect(avatarFinder, findsOneWidget);
-      final sizedBoxSize = tester.getSize(find.byType(SizedBox));
+      final innerAvatar = tester.getSize(find.descendant(
+          of: avatarFinder, matching: find.byType(ActerAvatar)));
       // expect parent badge fallback size.
-      expect(sizedBoxSize.height, equals(20));
-      expect(sizedBoxSize.width, equals(20));
+      expect(innerAvatar.height, equals(20));
+      expect(innerAvatar.width, equals(20));
     });
-    testWidgets('Rectangular Avatar Parent badge with NetworkImage render',
+    testWidgets('Space Avatar Parent badge with NetworkImage render',
         (WidgetTester tester) async {
       final String imagePath =
           'https://st5.depositphotos.com/38460822/63964/i/600/depositphotos_639649504-stock-photo-mail-sign-sign-alphabet-made.jpg';
@@ -190,7 +191,7 @@ void main() {
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(
           body: ActerAvatar(
-            key: TestKeys.rectangleAvatarKey,
+            key: TestKeys.spaceAvatarKey,
             avatarInfo: AvatarInfo(uniqueId: '@test:acter.org'),
             avatarsInfo: [AvatarInfo(uniqueId: 'Acter-Global', avatar: image)],
             mode: DisplayMode.Space,
@@ -198,7 +199,7 @@ void main() {
         ),
       ));
       await tester.pumpAndSettle();
-      final avatarFinder = find.byKey(TestKeys.rectangleAvatarKey);
+      final avatarFinder = find.byKey(TestKeys.spaceAvatarKey);
       // should expect `ActerAvatar` is present
       expect(avatarFinder, findsOneWidget);
       final avatar = avatarFinder.evaluate().first.widget as ActerAvatar;
@@ -339,7 +340,7 @@ void main() {
                       onTapped(context, 'Group Chat Avatar tapped'),
                 ),
                 ActerAvatar(
-                  key: TestKeys.rectangleAvatarKey,
+                  key: TestKeys.spaceAvatarKey,
                   avatarInfo: AvatarInfo(uniqueId: '@test:acter.org'),
                   mode: DisplayMode.Space,
                   onAvatarTap: () => onTapped(context, 'Space Avatar tapped'),
@@ -368,7 +369,7 @@ void main() {
       expect(groupChatGestureFinder, findsOneWidget);
 
       final spaceGestureFinder = find.descendant(
-          of: find.byKey(TestKeys.rectangleAvatarKey),
+          of: find.byKey(TestKeys.spaceAvatarKey),
           matching: find.byType(GestureDetector));
       // we have found the Gesture Detector, proceed with tester operation
       expect(spaceGestureFinder, findsOneWidget);


### PR DESCRIPTION
As reported in https://github.com/acterglobal/a3/issues/1184 : When the main avatar is going to fallback, we didn't show the parent avatar properly. 

1. Added an Example showing the problem (notice the parent of the third from the left)
   ![acter-avatar-fallback-failure](https://github.com/deniscolak/colorize-text-avatar/assets/40496/70bcdac9-15a5-4df5-b877-4c11ad6b4f89)
2. Simplify code to just reuse the inner avatar for the parent
3. Show it works:
   ![working--mini](https://github.com/deniscolak/colorize-text-avatar/assets/40496/e2e52ec4-d0a3-45c9-bbe1-c5cfbcba2326)
4. Add changelog entry
5. Fix tests
6. Add refreshing of avatar data upon Widget changes (to react to provider updates of avatar data)
